### PR TITLE
Fix preflight function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tendermint/vue",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/SpSignIn.vue
+++ b/src/components/SpSignIn.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    {{ foo }}
     <div class="container">
       <div class="row">
         <div class="button" v-if="address">

--- a/src/components/SpTypeForm.vue
+++ b/src/components/SpTypeForm.vue
@@ -93,8 +93,8 @@ export default {
       default: () => [],
     },
     preflight: {
-      default: (obj) => {
-        return obj;
+      default: () => {
+        return (obj) => obj;
       },
     },
   },
@@ -104,7 +104,7 @@ export default {
     SpH3,
     SpButton,
   },
-  data: function () {
+  data: function() {
     return {
       fieldsList: {},
       flight: false,


### PR DESCRIPTION
Right now we have an error when a user tries to submit the form.

```
[Vue warn]: Error in v-on handler (Promise/async): "TypeError: _this2.preflight is not a function"
```

This should fix it.