### PR TITLE
Stargate Integration

### DIFF
--- a/src/components/SpBlockExplorer.vue
+++ b/src/components/SpBlockExplorer.vue
@@ -115,11 +115,7 @@ export default {
 		 *
 		 */
 		...mapMutations('cosmos', ['popOverloadBlocks']),
-		...mapActions('cosmos', [
-			'addBlockEntry',
-			'getBlockchain',
-			'setHighlightedBlock'
-		]),
+		...mapActions('cosmos', ['addBlockEntry', 'getBlockchain']),
 		/*
 		 *
 		 * Local

--- a/src/components/SpBlockExplorer/BlockChain.vue
+++ b/src/components/SpBlockExplorer/BlockChain.vue
@@ -191,10 +191,10 @@ export default {
 				.reduce((accu, curr) => accu + curr)
 		},
 		getBlockNoteCopy(count, singularUnit) {
-			return `${count} ${singularUnit} ${count > 1 ? 's' : ''}`
+			return `${count} ${singularUnit}${count > 1 ? 's' : ''}`
 		},
 		getFailedTxsCount(txs) {
-			return txs.filter(tx => tx.code).length
+			return txs.filter(tx => tx.meta.code > 0).length
 		},
 		handleCardClicked(event) {
 			const blockHash = event.currentTarget.id
@@ -422,7 +422,7 @@ export default {
 	width: 5px;
 	height: 5px;
 	border-radius: 100%;
-	background-color: var(--sp-c-danger-primary);
+	background-color: var(--sp-c-txt-danger);
 	margin-right: 6px;
 	transform: translate3d(0, -2px, 0);
 }

--- a/src/components/SpBlockExplorer/BlockChain.vue
+++ b/src/components/SpBlockExplorer/BlockChain.vue
@@ -96,7 +96,6 @@ export default {
 		 * Vuex
 		 *
 		 */
-		...mapGetters('cosmos', ['appEnv']),
 		...mapGetters('cosmos', [
 			'highlightedBlock',
 			'blocksStack',
@@ -188,7 +187,7 @@ export default {
 		},
 		getMsgsAmount(txs) {
 			return txs
-				.map(tx => tx.tx.value.msg.length)
+				.map(tx => tx.body.messages.length)
 				.reduce((accu, curr) => accu + curr)
 		},
 		getBlockNoteCopy(count, singularUnit) {
@@ -201,7 +200,9 @@ export default {
 			const blockHash = event.currentTarget.id
 			const blockPayload = {
 				id: blockHash,
-				data: this.blockHelpers.getFormattedBlock(this.blockByHash(blockHash))[0]
+				data: this.blockHelpers.getFormattedBlock(
+					this.blockByHash(blockHash)
+				)[0]
 			}
 
 			this.setHighlightedBlock({ block: blockPayload })

--- a/src/components/SpBlockExplorer/BlockChain.vue
+++ b/src/components/SpBlockExplorer/BlockChain.vue
@@ -58,6 +58,7 @@
 </template>
 
 <script>
+import _ from 'lodash'
 import { mapGetters, mapActions } from 'vuex'
 import moment from 'moment'
 

--- a/src/components/SpBlockExplorer/BlockDetailSheet.vue
+++ b/src/components/SpBlockExplorer/BlockDetailSheet.vue
@@ -82,12 +82,12 @@
 										:tooltip-direction="'left'"
 									/>
 								</div>
-								<div class="tx__info-content tx-info">
+								<!-- <div class="tx__info-content tx-info">
 									<span class="tx-info__title">Gas Used / Wanted</span>
 									<p class="tx-info__content">
 										{{ `${tx.gas_used} / ${tx.gas_wanted}` }}
 									</p>
-								</div>
+								</div> -->
 								<div class="tx__info-content tx-info">
 									<span class="tx-info__title">Fee</span>
 									<p class="tx-info__content">{{ getTxFee(tx) }}</p>
@@ -135,7 +135,6 @@ export default {
 			return momentTime.format('MMM D YYYY, HH:mm:ss')
 		},
 		getTxFee(tx) {
-			console.log(tx)
 			const amount = tx.auth_info.fee.amount
 			return amount.length < 1 ? '0' : `${amount[0].amount} ${amount[0].denom}`
 		},

--- a/src/components/SpBlockExplorer/BlockDetailSheet.vue
+++ b/src/components/SpBlockExplorer/BlockDetailSheet.vue
@@ -53,17 +53,17 @@
 
 						<div class="tx__main-cards">
 							<YamlCards
-								:contents="tx.tx.value.msg"
+								:contents="tx.body.messages"
 								:card-type="
-									getCardCounts(tx.tx.value.msg) > 1 ? 'Messages' : 'Message'
+									getCardCounts(tx.body.messages) > 1 ? 'Messages' : 'Message'
 								"
 							/>
-							<YamlCards
+							<!-- <YamlCards
 								:contents="getEvents(tx)"
 								:card-type="
 									getCardCounts(getEvents(tx)) > 1 ? 'Events' : 'Event'
 								"
-							/>
+							/> -->
 						</div>
 					</div>
 					<div class="tx__side">
@@ -75,9 +75,9 @@
 									<span class="tx-info__title">Hash</span>
 									<CopyIconText
 										class="copy-icon-text"
-										:text="tx.txhash"
-										:link="`${appEnv.RPC}/tx?hash=0x${tx.txhash}`"
-										:copy-content="tx.txhash"
+										:text="tx.txHash"
+										:link="`${appEnv.RPC}/tx?hash=0x${tx.txHash}`"
+										:copy-content="tx.txHash"
 										:tooltip-text="'TxHash is copied'"
 										:tooltip-direction="'left'"
 									/>
@@ -92,9 +92,9 @@
 									<span class="tx-info__title">Fee</span>
 									<p class="tx-info__content">{{ getTxFee(tx) }}</p>
 								</div>
-								<div v-if="tx.tx.value.memo" class="tx__info-content tx-info">
+								<div v-if="tx.body.memo" class="tx__info-content tx-info">
 									<span class="tx-info__title">Memo</span>
-									<p class="tx-info__content">{{ tx.tx.value.memo }}</p>
+									<p class="tx-info__content">{{ tx.body.memo }}</p>
 								</div>
 							</div>
 						</div>
@@ -135,7 +135,7 @@ export default {
 			return momentTime.format('MMM D YYYY, HH:mm:ss')
 		},
 		getTxFee(tx) {
-			const amount = tx.tx.value.fee.amount
+			const amount = tx.auth_info.fee.amount
 			return amount.length < 1 ? '0' : `${amount[0].amount} ${amount[0].denom}`
 		},
 		getEvents(tx) {

--- a/src/components/SpBlockExplorer/BlockDetailSheet.vue
+++ b/src/components/SpBlockExplorer/BlockDetailSheet.vue
@@ -135,6 +135,7 @@ export default {
 			return momentTime.format('MMM D YYYY, HH:mm:ss')
 		},
 		getTxFee(tx) {
+			console.log(tx)
 			const amount = tx.auth_info.fee.amount
 			return amount.length < 1 ? '0' : `${amount[0].amount} ${amount[0].denom}`
 		},

--- a/src/components/SpBlockExplorer/BlockDetailSheet.vue
+++ b/src/components/SpBlockExplorer/BlockDetailSheet.vue
@@ -46,9 +46,9 @@
 					class="txs__tx tx"
 				>
 					<div class="tx__main">
-						<div v-if="tx.code" class="tx__error">
+						<div v-if="tx.meta.code" class="tx__error">
 							<span class="tx__error-title">Error</span>
-							<p class="tx__error-msg">{{ tx.raw_log }}</p>
+							<p class="tx__error-msg">{{ tx.meta.log }}</p>
 						</div>
 
 						<div class="tx__main-cards">
@@ -82,12 +82,12 @@
 										:tooltip-direction="'left'"
 									/>
 								</div>
-								<!-- <div class="tx__info-content tx-info">
+								<div class="tx__info-content tx-info">
 									<span class="tx-info__title">Gas Used / Wanted</span>
 									<p class="tx-info__content">
-										{{ `${tx.gas_used} / ${tx.gas_wanted}` }}
+										{{ `${tx.meta.gas_used} / ${tx.meta.gas_wanted}` }}
 									</p>
-								</div> -->
+								</div>
 								<div class="tx__info-content tx-info">
 									<span class="tx-info__title">Fee</span>
 									<p class="tx-info__content">{{ getTxFee(tx) }}</p>
@@ -126,7 +126,7 @@ export default {
 	computed: {
 		...mapGetters('cosmos', ['appEnv']),
 		failedTxsCount() {
-			return this.block.data.txs.filter(tx => tx.code).length
+			return this.block.data.txs.filter(tx => tx.meta.code).length
 		}
 	},
 	methods: {
@@ -136,6 +136,8 @@ export default {
 		},
 		getTxFee(tx) {
 			const amount = tx.auth_info.fee.amount
+			if (!amount) return 'N/A'
+
 			return amount.length < 1 ? '0' : `${amount[0].amount} ${amount[0].denom}`
 		},
 		getEvents(tx) {
@@ -276,7 +278,7 @@ export default {
 	color: var(--sp-c-txt-danger);
 	padding: 1.25rem 1.5rem;
 	border-radius: 12px;
-	background-color: var(--sp-c-danger-light);
+	background-color: var(--sp-c-bg-danger);
 	margin-bottom: 1.5rem;
 }
 .tx__error-title {

--- a/src/components/SpBlockExplorer/SpBlockExplorer.vue
+++ b/src/components/SpBlockExplorer/SpBlockExplorer.vue
@@ -31,12 +31,12 @@
 
 <script>
 import { mapGetters, mapMutations, mapActions } from 'vuex'
-import blockHelpers from '../helpers/block'
+import blockHelpers from '../../helpers/block'
 
-import FullWidthContainer from './SpBlockExplorer/FullWidthContainer'
-import BlockDetailSheet from './SpBlockExplorer/BlockDetailSheet'
-import BlockChain from './SpBlockExplorer/BlockChain'
-import IconBox from './icons/Box'
+import FullWidthContainer from './FullWidthContainer'
+import BlockDetailSheet from './BlockDetailSheet'
+import BlockChain from './BlockChain'
+import IconBox from '../icons/Box'
 
 export default {
 	components: {

--- a/src/index.js
+++ b/src/index.js
@@ -10,4 +10,4 @@ export { default as SpStandardIconText } from './components/SpStandardIconText'
 export { default as SpLoaderIconText } from './components/SpLoaderIconText'
 
 export { default as SpBlockInfoCard } from './components/SpBlockInfoCard'
-export { default as SpBlockExplorer } from './components/SpBlockExplorer'
+export { default as SpBlockExplorer } from './components/SpBlockExplorer/SpBlockExplorer'

--- a/src/store/blocks.js
+++ b/src/store/blocks.js
@@ -406,6 +406,7 @@ actions.setBlockMeta = async (
 	}
 
 	if (txsData.txs && txsData.txs.length > 0) {
+		console.log(blockHolder)
 		const txsDecoded = txsData.txs.map(txEncoded =>
 			dispatch('getDecodedTx', {
 				txEncoded,
@@ -583,7 +584,6 @@ actions.initBlockConnection = async ({
 							dispatch('getDecodedTx', {
 								txEncoded: errObj.txError.txEncoded
 							}).then(txRes => {
-								console.log('🚀', txRes)
 								const isTxAlreadyDecoded =
 									errBlockInStack.txsDecoded.filter(
 										tx => tx.txHash === txRes.txHash
@@ -594,7 +594,7 @@ actions.initBlockConnection = async ({
 								}
 								getters.errorsQueue.splice(index, 1)
 								console.info(
-									`✨TX fetching error ${txRes.txhash} was resolved.`
+									`✨TX fetching error ${txRes.txHash} was resolved.`
 								)
 							})
 						}

--- a/src/store/blocks.js
+++ b/src/store/blocks.js
@@ -406,7 +406,6 @@ actions.setBlockMeta = async (
 	}
 
 	if (txsData.txs && txsData.txs.length > 0) {
-		console.log(blockHolder)
 		const txsDecoded = txsData.txs.map(txEncoded =>
 			dispatch('getDecodedTx', {
 				txEncoded,

--- a/src/store/env.js
+++ b/src/store/env.js
@@ -18,7 +18,8 @@ const state = {
 		RPC: '',
 		API: '',
 		WS: '',
-		ADDR_PREFIX: ''
+		ADDR_PREFIX: '',
+		GET_TX_API: ''
 	},
 	backend: {
 		sdk_version: 'Stargate',
@@ -88,6 +89,11 @@ export default {
 				'ws://localhost:26657/websocket'
 
 			state.APP_ENV.ADDR_PREFIX = VUE_APP_ADDRESS_PREFIX || 'cosmos'
+
+			state.APP_ENV.GET_TX_API =
+				state.backend.sdk_version === 'Stargate'
+					? `${state.APP_ENV.API}/cosmos/tx/v1beta1/tx/`
+					: `${state.APP_ENV.API}/txs/`
 		},
 		/**
 		 *
@@ -155,7 +161,7 @@ export default {
 				const { status, env } = data
 
 				state.CHAIN_ID = env.chain_id
-				state.sdk_version = status.sdk_version
+				state.backend.sdk_version = status.sdk_version
 
 				commit('setAppEnv', {
 					customUrl: env.vue_app_custom_url

--- a/src/store/env.js
+++ b/src/store/env.js
@@ -21,6 +21,7 @@ const state = {
 		ADDR_PREFIX: ''
 	},
 	backend: {
+		sdk_version: 'Stargate',
 		env: {
 			node_js: false,
 			vue_app_custom_url: process.env.VUE_APP_CUSTOM_URL
@@ -41,6 +42,7 @@ const state = {
 const getters = {
 	chainId: state => state.CHAIN_ID,
 	appEnv: state => state.APP_ENV,
+	sdkVersion: state => state.backend.sdk_version,
 	backendEnv: state => state.backend.env,
 	backendRunningStates: state => state.backend.running,
 	wasAppRestarted: state => status => {
@@ -153,6 +155,7 @@ export default {
 				const { status, env } = data
 
 				state.CHAIN_ID = env.chain_id
+				state.sdk_version = status.sdk_version
 
 				commit('setAppEnv', {
 					customUrl: env.vue_app_custom_url

--- a/src/store/env.js
+++ b/src/store/env.js
@@ -92,7 +92,7 @@ export default {
 
 			state.APP_ENV.GET_TX_API =
 				state.backend.sdk_version === 'Stargate'
-					? `${state.APP_ENV.API}/cosmos/tx/v1beta1/tx/`
+					? `${state.APP_ENV.RPC}/tx?hash=0x` // temp replacement of `${state.APP_ENV.API}/cosmos/tx/v1beta1/tx/`
 					: `${state.APP_ENV.API}/txs/`
 		},
 		/**

--- a/src/store/tx.js
+++ b/src/store/tx.js
@@ -37,7 +37,17 @@ const actions = {
 			txHolder.body = { messages, memo }
 			txHolder.auth_info = auth_info
 		} else {
-			// ⚠️ TODO: Sync with Launchpad version
+			const { txHash, data } = txDecoded
+			const { tx } = data
+			txHolder.txHash = txHash
+			txHolder.body = {
+				messages: tx.value.msg,
+				memo: tx.value.memo
+			}
+			txHolder.auth_info = {
+				signer_infos: tx.value.signatures,
+				fee: tx.value.fee
+			}
 		}
 
 		return txHolder
@@ -53,11 +63,11 @@ const actions = {
 	 */
 	async getRawDecodedTx({ rootGetters }, { txEncoded, errCallback }) {
 		const hashedTx = sha256(Buffer.from(txEncoded, 'base64'))
-		const { API } = rootGetters['cosmos/appEnv']
+		const { GET_TX_API } = rootGetters['cosmos/appEnv']
 		try {
 			// return await axios.post(`${API}/txs/decode`, { tx: txEncoded })
 			// return await axios.get(`${API}/txs/${hashedTx}`)
-			return await axios.get(`${API}/cosmos/tx/v1beta1/tx/${hashedTx}`)
+			return await axios.get(`${GET_TX_API}${hashedTx}`)
 		} catch (err) {
 			console.error(txEncoded, err)
 			if (errCallback) errCallback(txEncoded, err)

--- a/src/store/tx.js
+++ b/src/store/tx.js
@@ -6,57 +6,42 @@ const state = {
 }
 
 const getters = {
-	txsStack: state => state.stack,
 	txByHash: state => hash => state.stack.filter(tx => tx.txhash === hash),
 	txByEncodedHash: state => hash =>
 		state.stack.filter(tx => tx.txEncoded && tx.txEncoded === hash)
 }
 
-const mutations = {
-	addTxEntry(state, { tx }) {
-		/**
-		 *
-		 // 1. No txs in stack yet
-		 *
-		 */
-		if (state.stack.length === 0) {
-			state.stack.push(tx)
-			return
-		}
-
-		/**
-		 *
-		 // 2. Txs already exist in the stack
-		 *
-		 */
-		for (let txIndex = 0; txIndex < state.stack.length; txIndex++) {
-			const currentTxVal = state.stack[txIndex]
-			const nextTxVal = state.stack[txIndex + 1]
-
-			// Push tx to the end of the stack
-			if (!nextTxVal) {
-				state.stack.push(tx)
-				break
-			}
-
-			const txHeight = parseInt(tx.height)
-			const currentTxValHeight = parseInt(currentTxVal.height)
-			const nextTxValHeight = parseInt(nextTxVal.height)
-			// Add tx to the start of the stack
-			if (txHeight > currentTxValHeight && txIndex === 0) {
-				state.stack.unshift(tx)
-				break
-			}
-			// Insert tx to the stack
-			if (currentTxValHeight > txHeight && txHeight > nextTxValHeight) {
-				state.stack.splice(txIndex + 1, 0, tx)
-				break
-			}
-		}
-	}
-}
-
 const actions = {
+	/**
+	 *
+	 *
+	 */
+	setDecodedTxTemplate({ rootGetters }, { txDecoded }) {
+		const txHolder = {
+			txHash: '',
+			body: {
+				messages: [],
+				memo: ''
+			},
+			auth_info: {
+				signer_infos: [],
+				fee: {}
+			}
+		}
+
+		if (rootGetters['cosmos/sdkVersion'] === 'Stargate') {
+			const { txHash } = txDecoded
+			const { body, auth_info } = txDecoded.data.tx
+			const { messages, memo } = body
+			txHolder.txHash = txHash
+			txHolder.body = { messages, memo }
+			txHolder.auth_info = auth_info
+		} else {
+			// ⚠️ TODO: Sync with Launchpad version
+		}
+
+		return txHolder
+	},
 	/**
 	 *
 	 *
@@ -66,53 +51,43 @@ const actions = {
 	 *
 	 *
 	 */
-	async getDecodedTx({ rootGetters }, { txEncoded, errCallback }) {
+	async getRawDecodedTx({ rootGetters }, { txEncoded, errCallback }) {
 		const hashedTx = sha256(Buffer.from(txEncoded, 'base64'))
 		const { API } = rootGetters['cosmos/appEnv']
 		try {
 			// return await axios.post(`${API}/txs/decode`, { tx: txEncoded })
-			return await axios.get(`${API}/txs/${hashedTx}`)
+			// return await axios.get(`${API}/txs/${hashedTx}`)
+			return await axios.get(`${API}/cosmos/tx/v1beta1/tx/${hashedTx}`)
 		} catch (err) {
 			console.error(txEncoded, err)
 			if (errCallback) errCallback(txEncoded, err)
+			throw err
 		}
 	},
 	/**
-	 * Add tx into txsStack
-	 *
-	 * @param {object} store
-	 * @param {object} payload
-	 * @param {object} payload.txData
 	 *
 	 *
 	 */
-	addTxEntry({ commit, getters }, txData) {
-		/*
-		 *
-		 // If tx is null, it's not decoded successfully,
-		 // and triggered from `addErrorTx` in `blocks` store mutations.
-		 *
-		 */
-		const fmtTxData =
-			txData.tx === null
-				? {
-						height: txData.height,
-						txEncoded: txData.txEncoded
-				  }
-				: txData.data.tx
-
-		const isTxInStack =
-			txData.tx === null
-				? getters.txByEncodedHash(txData.txEncoded).length > 0
-				: getters.txByHash(txData.data.tx.txhash).length > 0
-
-		if (!isTxInStack) commit('addTxEntry', { tx: fmtTxData })
+	async getDecodedTx({ dispatch }, { txEncoded, errCallback }) {
+		return await dispatch('getRawDecodedTx', {
+			txEncoded,
+			errCallback
+		})
+			.then(txRes =>
+				dispatch('setDecodedTxTemplate', {
+					txDecoded: {
+						...txRes,
+						txHash: sha256(Buffer.from(txEncoded, 'base64')).toUpperCase()
+					}
+				}).then(fmtTx => fmtTx)
+			)
+			.catch(() => null)
 	}
 }
 
 export default {
 	state,
 	getters,
-	mutations,
+	mutations: {},
 	actions
 }

--- a/src/store/tx.js
+++ b/src/store/tx.js
@@ -95,8 +95,6 @@ const actions = {
 			}
 		}
 
-		console.log(txHolder)
-
 		return txHolder
 	},
 	/**

--- a/src/styles/_colors.css
+++ b/src/styles/_colors.css
@@ -92,6 +92,7 @@
 
   --sp-c-bg-primary: var(--c-theme-pure);
   --sp-c-bg-secondary: var(--c-theme-primary);
+  --sp-c-bg-danger: var(--c-danger-light);
 }
 
 .-sp-c-txt-primary {


### PR DESCRIPTION
### Description
- [x] Use gRPC gateway endpoint to fetch decoded tx value
- [x] Create fallback tx formatter for Launchpad version

### Todos
- [x] Understand why `gas_wanted`, `gas_used`, and `events` are missing from the decoded tx response
- [x] Resolve the failed tx fetching issue (#30)
- [x] Wait for [gRPC supports](https://github.com/tendermint/starport/pull/400) merged in Starport

### Notes
- Temporarily combining responses from two endpoints (RPC query and gRPC gateway) to get all required info.
- ~~Temporarily using `26657/tx?hash=0x{txhash}` endpoint to fetch tx instead of gRPC gateway, because of the inconsistent TxResponse format. Although this endpoint response is lack of `memo` and `fee` too.~~