### PR TITLE
docs: client js README grammatical suggestions for clarity

### DIFF
--- a/packages/client-js/README.md
+++ b/packages/client-js/README.md
@@ -1,6 +1,6 @@
 # `@starport/client-js`
 
-This package implements a generic JS client wrapper for the Tendermint RPC, Tendermint websocket, and Cosmos SDK REST APIs.
+This package implements a generic JS client wrapper for the Tendermint RPC, Tendermint WebSocket, and Cosmos SDK APIs.
 
 ## Install
 

--- a/packages/client-js/README.md
+++ b/packages/client-js/README.md
@@ -1,6 +1,6 @@
 # `@starport/client-js`
 
-Implements a generic JS client wrapper for the Tendermint RPC, Tendermint WS and Cosmos REST APIs.
+This package implements a generic JS client wrapper for the Tendermint RPC, Tendermint websocket, and Cosmos SDK REST APIs.
 
 ## Install
 
@@ -20,13 +20,13 @@ const client = new Client({
 
 ```
 
-The client implements EventEmitter and runs a periodic connectivity test so will emit the following events based on the connection state:
+The client implements EventEmitter, runs a periodic connectivity test, and emits the following events based on the connection state:
 
 * 'api-status' : true/false
 * 'rpc-status' : true/false
 * 'ws-status' : true/false
 
-You can listen for and handle those in your application in the standard way:
+You can listen for and handle those events in your app in the standard way:
 
 ```
 client.on('api-status', (status) => { 
@@ -48,7 +48,7 @@ client.switchRPC('<new_rpc_node_address>');
 client.switchWS('<new_ws_node_address>');
 ```
 
-The client automatically subscribes to new block events and emits those for handling:
+The client automatically subscribes to new block events and emits the events for handling:
 
 ```
 client.on('newblock',(block) => {
@@ -58,11 +58,11 @@ client.on('newblock',(block) => {
 
 ### Additional features
 
-Client provides a `useSigner()` method to connect a signer/wallet implementing the CosmJS OfflineDirectSigner interface (https://cosmos.github.io/cosmjs/latest/proto-signing/interfaces/signer.offlinedirectsigner.html).
+The client provides a `useSigner()` method to connect a signer or wallet using the [CosmJS OfflineDirectSigner interface](https://cosmos.github.io/cosmjs/latest/proto-signing/interfaces/signer.offlinedirectsigner.html).
 
-The resulting CosmJS signing client (https://cosmos.github.io/cosmjs/latest/stargate/classes/signingstargateclient.signingstargateclient-1.html) is accessible via the `.signingClient` property while the signer is accessible via the `.signer` property.
+To access the resulting [CosmJS signing client](https://cosmos.github.io/cosmjs/latest/stargate/classes/signingstargateclient.signingstargateclient-1.html), use the `.signingClient` property. To access the signer, use the `.signer` property.
 
-Using the client's `.switchRPC()` method mentioned above will reinstantiate the signing client appropriately.
+Using the client `.switchRPC()` method reinstantiates the signing client appropriately.
 
 ```
 const signer = await DirectSecp256k1HdWallet.fromMnemonic(mymnemonic) // or any other object implementing the OfflineDirectSigner interface
@@ -81,13 +81,13 @@ const amount = {
 const result = await client.signingClient.sendTokens(account.address, recipient, [amount], "Memo Message");
 ```
 
-Finally, the client provides two querying methods for the cosmos API:
+Finally, the client provides two querying methods for the Cosmos SDK API:
 
 ### query()
 
 `.query(endpoint,queryparams)` 
 
-A VERY basic wrapper around axios, so querying the bank module for an address's balances would be: 
+A basic wrapper around Axios. For example, to query the bank module for an address's balances: 
 
 ```
 let balances = await client.query('/cosmos/bank/v1beta1/balances/','cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5');
@@ -103,4 +103,4 @@ let balances = await client.query('/cosmos/bank/v1beta1/balances/','cosmos1xv9tk
   })
 ```
 
-A helper method compatible with the swagger-typescript-api API classes generated with the `--single-http-client` if you have generated API classes for your chain's endpoints via their swagger definitions.
+This helper method is compatible with the swagger-typescript-api API classes that are generated with `--single-http-client` by using their Swagger definitions if the generated API classes exist for your chain endpoints.


### PR DESCRIPTION
Wording/content questions:
line 61: let's not use a slash (/) to mean and/or, is it `signer`, `wallet`, or both? 
line 84: do we always call the API the `Cosmos API`? or is the correct name the `Cosmos SDK API`? 
all lines: @clockworkgr teach me! I am learning and want to hear if this PR was helpful, or how I can do better.

