### PR TITLE
fix: Add @cosmjs deps

### DIFF
--- a/packages/vuex/package.json
+++ b/packages/vuex/package.json
@@ -21,7 +21,13 @@
   },
   "dependencies": {
     "@confio/relayer": "0.1.2",
-    "@starport/client-js": "^0.1.46",
+    "@starport/client-js": "^0.1.46",    
+    "@cosmjs/launchpad": "0.25.0-alpha.2",
+    "@cosmjs/proto-signing": "0.25.0-alpha.2",
+    "@cosmjs/crypto": "0.25.0-alpha.2",
+    "@cosmjs/utils": "0.25.0-alpha.2",
+    "@cosmjs/stargate": "0.25.0-alpha.2",
+    "@cosmjs/tendermint-rpc": "0.25.0-alpha.2",
     "axios": "0.21.1",
     "bs58": "4.0.1",
     "crypto-js": "4.0.0"


### PR DESCRIPTION
Although @cosmjs deps in vuex relayers module should be resolvable as dependencies of @confio relayer, npm occasionally complains.

Hence they're explicitly added here.
