### PR TITLE
fix(template): added no-legacy-stdTx flag

### DIFF
--- a/packages/vue/src/components/SpWalletCreate/SpWalletCreate.vue
+++ b/packages/vue/src/components/SpWalletCreate/SpWalletCreate.vue
@@ -304,6 +304,7 @@ export default defineComponent({
 
         try {
           await window.keplr.experimentalSuggestChain({
+            features: ['no-legacy-stdTx'],
             chainId: chainId,
             chainName: this.$store.getters['common/env/chainName'],
             rpc: this.$store.getters['common/env/apiTendermint'],


### PR DESCRIPTION
Related issues:

[Legacy endpoint /txs with stargate v0.44 keplr transaction fails with basic send-token](https://github.com/chainapsis/keplr-extension/issues/167)

[Signing transactions with Keplr error](https://github.com/tendermint/vue/issues/128)