### PR TITLE
fix: Remove chevron from selected denom

### DIFF
--- a/packages/vue/src/components/SpAmountSelect/SpAmountSelect.vue
+++ b/packages/vue/src/components/SpAmountSelect/SpAmountSelect.vue
@@ -12,19 +12,6 @@
       <div class="token-info">
         <div class="token-denom">
           <SpDenom :denom="x.amount.denom" />
-          <svg
-            width="12"
-            height="8"
-            viewBox="0 0 12 8"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            style="margin-left: 6px"
-          >
-            <path
-              d="M5.99998 7.4L0.599976 2L1.99998 0.599998L5.99998 4.6L9.99998 0.599998L11.4 2L5.99998 7.4Z"
-              fill="black"
-            />
-          </svg>
         </div>
 
         <div


### PR DESCRIPTION
## Description & Context

At the moment we have a misunderstanding about the functionality of replacing the selected Denom and the chevron down should be removed until we implement something else.

## How To Test

1. Connect Wallet;
2. On the already pre-selected Denom, you should not see the chevron icon;

## Linked issue

Closes #219 