### PR TITLE
feat(vuex): add env getter for new client

### DIFF
--- a/packages/vuex/src/modules/common/env/env.js
+++ b/packages/vuex/src/modules/common/env/env.js
@@ -45,7 +45,20 @@ export default {
     sdkVersion: (state) => state.sdkVersion,
     apiConnected: (state) => state.apiConnected,
     rpcConnected: (state) => state.rpcConnected,
-    wsConnected: (state) => state.wsConnected
+    wsConnected: (state) => state.wsConnected,
+    getEnv: (state) => ({
+      chainID: state.chainId,      
+      chainName: state.chainName,
+      apiURL: state.apiCosmos,
+      rpcURL: state.apiTendermint,
+      wsURL: state.apiWS,
+      prefix: state.addrPrefix,
+      status: {
+        apiConnected: state.apiConnected,
+        rpcConnected: state.rpcConnected,
+        wsConnected: state.wsConnected
+      }
+    })
   },
   mutations: {
     SET_CONFIG(state, config) {


### PR DESCRIPTION
adds a new `common/env/getEnv` getter to `@starport/vuex` thaty returns the full environment details for use with the new/refactored typescript client in https://github.com/ignite/cli